### PR TITLE
Ribbon alternative styles

### DIFF
--- a/style.css
+++ b/style.css
@@ -1399,9 +1399,10 @@ a:hover, a:active {
 
 .entry-title,
 .page-title {
-	font-size: 32px;
-	font-size: 2rem;
-	margin-bottom: 0;
+	font-size: 40px;
+	font-size: 2.5rem;
+	line-height: 1.3;
+	margin-bottom: 0.35em;
 }
 
 .entry-title a,


### PR DESCRIPTION
Posting as an optional fix for #29 - it puts the ribbon behind the post meta instead, so post headers will look something like:

![](https://cldup.com/1Cz-p2yqG4-3000x3000.png)

If we went this route, we'd probably want to make the post/page title a little stronger -- I made it a bit bigger to help it stand out more, but maybe more contrast would help, too?